### PR TITLE
Fix issue with client linking when having multiple games

### DIFF
--- a/echelon/inc/functions.php
+++ b/echelon/inc/functions.php
@@ -517,8 +517,14 @@ function tooltip($msg, $float = false) {
  * Echo out simple clientdetails link
  */
 function clientLink($name, $id, $game_id = NULL) {
-	if(!empty($game_id))
+    if(empty($game_id)){
+        global $game;
+        if(!empty($game))
+            $game_id = $game;
+    }
+    if(!empty($game_id))
 		$href = '&amp;game='.$game_id;
+
 
 	return '<a href="clientdetails.php?id='.$id.$href.'" title="Check out '.$name.' client information profile">'.$name.'</a>';
 }

--- a/echelon/index.php
+++ b/echelon/index.php
@@ -28,7 +28,7 @@ require 'inc/header.php';
 		if(isHome()) {
 			$latest = getEchVer();
 			if(ECH_VER !== $latest && $latest != false) // if current version does not equal latest version show warning message
-				set_warning('You are not using the lastest version of Echelon. Please check the <a href="https://github.com/miltann/Echelon-2">Echelon Github repository</a> for the latest version.');
+				set_warning('You are not using the latest version of Echelon. Please check the <a href="https://github.com/miltann/Echelon-2">Echelon Github repository</a> for the latest version.');
 		}
 	endif;
     	errors(); // echo out all errors/success/warnings

--- a/echelon/install/index.php
+++ b/echelon/install/index.php
@@ -130,7 +130,7 @@
 		## Send the admin their email ##
 		$body = '<html><body>';
 		$body .= '<h2>Echelon Admin User Information</h2>';
-		$body .= 'This is the admin user login informtion.<br />';
+		$body .= 'This is the admin user login information.<br />';
 		$body .= 'Username: <b>admin</b><br />';	
 		$body .= 'Password: <b>' . $user_pw . "</b><br />";
 		$body .= 'If you have not already, please entirely remove the install folder from Echelon (/echelon/install/).<br />';
@@ -189,7 +189,7 @@
 							<h3>Things that are done</h3>
 							<ul>
 								<li>The database information you provided was correct</li>
-								<li>Your config file was writen</li>
+								<li>Your config file was written</li>
 								<li>An email was sent, to the email address you supplied, with the user information for your Echelon 'Admin' account</li>
 							</ul>
 						</div>


### PR DESCRIPTION
We faced an issue where 2 clients from 2 different games had same client id, lets say `@3` and when we clicked on one of them, we were redirected to the other one.

For example, we had `@3 player1`, `@3 player2`, and when we clicked on player2 to see client details, it opened player1 profile.

I have noticed `clientLink()` function in `functions.php` creates those links and if you pass a third argument, `$game_id` to that method, this issue will be fixed. But none of the callers passed the third argument.
Therefore I altered that method to use `global $game`(which will be read from cookie or query string, based on the data in `setup.php`) to fill `$game_id` **only if `$game_id` is empty**.

This completely fixes issue for normal cases and we are using it at Repz now. One common issue is that if you open different echelon tabs with different clients, each tab might mess with the data from other tab. It rarely happens and I believe its avoidable.

---
Also, a few typos were fixed :) 